### PR TITLE
Bump AntLoader to version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "php": ">=8.0",
-        "antcms/antloader": "^1.0.0",
+        "antcms/antloader": "^2.0.0",
         "elgigi/commonmark-emoji": "^2.0",
         "embed/embed": "^4.4",
         "league/commonmark": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4bd5e3a9fdba1a9f97f8a6c97d7888c0",
+    "content-hash": "a71a49f6dbfd02f59e0f0203188efec1",
     "packages": [
         {
             "name": "antcms/antloader",
-            "version": "1.0.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AntCMS-org/AntLoader.git",
-                "reference": "9f34f0fdb0cb601ead37f07bdb303ef397a82db9"
+                "reference": "19c70b9038ff6cfee2f0e669d0ecbb55334b6e62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AntCMS-org/AntLoader/zipball/9f34f0fdb0cb601ead37f07bdb303ef397a82db9",
-                "reference": "9f34f0fdb0cb601ead37f07bdb303ef397a82db9",
+                "url": "https://api.github.com/repos/AntCMS-org/AntLoader/zipball/19c70b9038ff6cfee2f0e669d0ecbb55334b6e62",
+                "reference": "19c70b9038ff6cfee2f0e669d0ecbb55334b6e62",
                 "shasum": ""
             },
             "require": {
@@ -47,9 +47,9 @@
             "description": "A small and simple autoloader for PHP applications",
             "support": {
                 "issues": "https://github.com/AntCMS-org/AntLoader/issues",
-                "source": "https://github.com/AntCMS-org/AntLoader/tree/1.0.2"
+                "source": "https://github.com/AntCMS-org/AntLoader/tree/2.0.0"
             },
-            "time": "2023-05-09T05:30:02+00:00"
+            "time": "2023-05-27T08:44:01+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -2042,16 +2042,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v4.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
                 "shasum": ""
             },
             "require": {
@@ -2092,9 +2092,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-05-19T20:20:00+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2209,16 +2209,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.14",
+            "version": "1.10.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
+                "reference": "762c4dac4da6f8756eebb80e528c3a47855da9bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
-                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/762c4dac4da6f8756eebb80e528c3a47855da9bd",
+                "reference": "762c4dac4da6f8756eebb80e528c3a47855da9bd",
                 "shasum": ""
             },
             "require": {
@@ -2267,7 +2267,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-19T13:47:27+00:00"
+            "time": "2023-05-09T15:28:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2589,16 +2589,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.7",
+            "version": "9.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
                 "shasum": ""
             },
             "require": {
@@ -2672,7 +2672,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
             },
             "funding": [
                 {
@@ -2688,7 +2688,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-14T08:58:40+00:00"
+            "time": "2023-05-11T05:14:45+00:00"
         },
         {
             "name": "rector/rector",
@@ -3051,16 +3051,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -3105,7 +3105,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -3113,7 +3113,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",

--- a/src/cron.php
+++ b/src/cron.php
@@ -2,8 +2,8 @@
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'Vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 $classMapPath = __DIR__  . DIRECTORY_SEPARATOR .  'Cache'  . DIRECTORY_SEPARATOR .  'classMap.php';
-$loader = new AntCMS\AntLoader($classMapPath);
-$loader->addPrefix('AntCMS\\', __DIR__  . DIRECTORY_SEPARATOR . 'AntCMS');
+$loader = new AntCMS\AntLoader(['path' => $classMapPath]);
+$loader->addNamespace('AntCMS\\', __DIR__  . DIRECTORY_SEPARATOR . 'AntCMS');
 $loader->checkClassMap();
 $loader->register();
 

--- a/src/index.php
+++ b/src/index.php
@@ -7,8 +7,8 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'Vendor' . DIRECTORY_SEPARATOR . 'a
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'Constants.php';
 
 $classMapPath = __DIR__  . DIRECTORY_SEPARATOR .  'Cache'  . DIRECTORY_SEPARATOR .  'classMap.php';
-$loader = new AntCMS\AntLoader($classMapPath);
-$loader->addPrefix('AntCMS\\', __DIR__  . DIRECTORY_SEPARATOR . 'AntCMS');
+$loader = new AntCMS\AntLoader(['path' => $classMapPath]);
+$loader->addNamespace('AntCMS\\', __DIR__  . DIRECTORY_SEPARATOR . 'AntCMS');
 $loader->checkClassMap();
 $loader->register();
 

--- a/tests/Includes/Include.php
+++ b/tests/Includes/Include.php
@@ -5,7 +5,7 @@ $srcdir = $basedir . DIRECTORY_SEPARATOR . 'src';
 include_once $srcdir . DIRECTORY_SEPARATOR . 'Constants.php';
 
 $classMapPath = $srcdir  . DIRECTORY_SEPARATOR .  'Cache'  . DIRECTORY_SEPARATOR .  'classMap.php';
-$loader = new AntCMS\AntLoader($classMapPath );
-$loader->addPrefix('AntCMS\\', $srcdir  . DIRECTORY_SEPARATOR . 'AntCMS');
+$loader = new AntCMS\AntLoader(['path' => $classMapPath]);
+$loader->addNamespace('AntCMS\\', $srcdir  . DIRECTORY_SEPARATOR . 'AntCMS');
 $loader->checkClassMap();
 $loader->register();


### PR DESCRIPTION
Bumps to handle [version 2](https://github.com/AntCMS-org/AntLoader/releases/tag/2.0.0) which has some (small) breaking changes