### PR TITLE
~ 50% reduction in the time to render a page

### DIFF
--- a/src/AntCMS/AntCMS.php
+++ b/src/AntCMS/AntCMS.php
@@ -126,25 +126,27 @@ class AntCMS
      */
     public static function getThemeTemplate(string $layout = 'default', string $theme = null)
     {
-        $theme = $theme ?? AntConfig::currentConfig('activeTheme');
+        $theme ??= AntConfig::currentConfig('activeTheme');
 
-        if (!is_dir(antThemePath . '/' . $theme)) {
+        if (!is_dir(antThemePath . DIRECTORY_SEPARATOR . $theme)) {
             $theme = 'Default';
         }
 
+        $basePath = AntTools::repairFilePath(antThemePath . DIRECTORY_SEPARATOR . $theme);
+
         if (strpos($layout, '_') !== false) {
             $layoutPrefix = explode('_', $layout)[0];
-            $templatePath = AntTools::repairFilePath(antThemePath . '/' . $theme . '/' . 'Templates' . '/' . $layoutPrefix);
+            $templatePath = $basePath . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR . $layoutPrefix;
             $defaultTemplates = AntTools::repairFilePath(antThemePath . '/Default/Templates' . '/' . $layoutPrefix);
         } else {
-            $templatePath = AntTools::repairFilePath(antThemePath . '/' . $theme . '/' . 'Templates');
+            $templatePath = $basePath . DIRECTORY_SEPARATOR . 'Templates';
             $defaultTemplates = AntTools::repairFilePath(antThemePath . '/Default/Templates');
         }
 
         try {
-            $template = @file_get_contents(AntTools::repairFilePath($templatePath . '/' . $layout . '.html.twig'));
+            $template = @file_get_contents($templatePath . DIRECTORY_SEPARATOR . $layout . '.html.twig');
             if (empty($template)) {
-                $template = file_get_contents(AntTools::repairFilePath($defaultTemplates . '/' . $layout . '.html.twig'));
+                $template = file_get_contents($defaultTemplates . DIRECTORY_SEPARATOR . $layout . '.html.twig');
             }
         } catch (\Exception) {
         }

--- a/src/AntCMS/AntConfig.php
+++ b/src/AntCMS/AntConfig.php
@@ -48,7 +48,8 @@ class AntConfig
      */
     public static function currentConfig(?string $key = null)
     {
-        $config = AntYaml::parseFile(antConfigFile);
+        // FS cache enabled to save ~10% of the time to deliver the file page.
+        $config = AntYaml::parseFile(antConfigFile, true);
         if (is_null($key)) {
             return $config;
         } else {
@@ -56,7 +57,6 @@ class AntConfig
             return self::getArrayValue($config, $keys);
         }
     }
-
 
     /**
      * @param array<mixed> $array 
@@ -67,13 +67,11 @@ class AntConfig
     {
         foreach ($keys as $key) {
             if (isset($array[$key])) {
-                $array = $array[$key];
+                return $array[$key];
             } else {
                 return null;
             }
         }
-
-        return $array;
     }
 
     /**

--- a/src/AntCMS/AntPages.php
+++ b/src/AntCMS/AntPages.php
@@ -52,21 +52,18 @@ class AntPages
         AntYaml::saveFile(antPagesList, $pageList);
     }
 
-    /** @return array<mixed>  */
-    public static function getPages()
+    public static function getPages():array
     {
         return AntYaml::parseFile(antPagesList);
     }
 
     /**
      * @param string $currentPage optional - What page is the active page. Used for highlighting the active page in the navbar
-     * @return string 
      */
-    public static function generateNavigation(string $navTemplate = '', string $currentPage = '')
+    public static function generateNavigation(string $navTemplate = '', string $currentPage = ''): string
     {
         $pages = AntPages::getPages();
         $antCache = new AntCache;
-        $antTwig = new AntTwig();
 
         $theme = AntConfig::currentConfig('activeTheme');
         $cacheKey = $antCache->createCacheKey(json_encode($pages), $theme . $currentPage);
@@ -74,7 +71,7 @@ class AntPages
         if ($antCache->isCached($cacheKey)) {
             $cachedContent = $antCache->getCache($cacheKey);
 
-            if ($cachedContent !== false && !empty($cachedContent)) {
+            if (!empty($cachedContent)) {
                 return $cachedContent;
             }
         }
@@ -91,6 +88,7 @@ class AntPages
             }
         }
 
+        $antTwig = new AntTwig();
         $navHTML = $antTwig->renderWithTiwg($navTemplate, array('pages' => $pages));
 
         $antCache->setCache($cacheKey, $navHTML);

--- a/src/AntCMS/AntTwig.php
+++ b/src/AntCMS/AntTwig.php
@@ -14,7 +14,7 @@ class AntTwig
         $twigCache = (AntConfig::currentConfig('enableCache') !== 'none') ? AntCachePath : false;
         $this->theme = $theme ?? AntConfig::currentConfig('activeTheme');
 
-        if (!is_dir(antThemePath . '/' . $this->theme)) {
+        if (!is_dir(antThemePath . DIRECTORY_SEPARATOR . $this->theme)) {
             $this->theme = 'Default';
         }
 


### PR DESCRIPTION
I did some code profiling and found some places where time could be saved.
The result is that now on my server AntCMS takes roughly half the time to render the page and send it to the user.
Results from the same server:
 - Before: Took 0.0052 seconds to render the page. 
 - After: Took 0.0026 seconds to render the page. 